### PR TITLE
Changed google+ community  to the new google group

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Have you ever been at "remote" party or tried to listen few parallel discussions
 
 ## Online Communities
 
-- [EventStormers Google+ Community](https://plus.google.com/u/0/communities/113258571348605620818)
+- [EventStormers Google Group Community](https://groups.google.com/forum/#!forum/eventstorming)
 - [DDD/CQRS/ES Slack see the #event-storming channel](https://ddd-cqrs-es.herokuapp.com/)
 
 ## Related topics


### PR DESCRIPTION
Removed the google+ link and replaced by the new Google group created by @ziobrando.  
this will solve #17 
