### PR TITLE
feat: Add Event Storming Template for Diagrams.net in Tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Have you ever been at "remote" party or tried to listen few parallel discussions
 
 #### Tools
 - [prooph board - The Online Event Storming Platform](https://prooph-board.com)
+- [Event Storming Template for Diagrams.net (formerly known as Draw.io).](https://github.com/josenaldo/event-storming-template)
 
 #### Other resources
 


### PR DESCRIPTION
Added a link to a template for creating Event Storming diagrams on [Diagrams.net](https://app.diagrams.net/) (formerly known as Draw.io).
![image](https://github.com/user-attachments/assets/7bacd819-db26-48d3-8784-fe9f532595e6)
