### PR TITLE
Add DDD Toolbox to Remote EventStorming Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Have you ever been at "remote" party or tried to listen few parallel discussions
 
 #### Tools
 - [prooph board - The Online Event Storming Platform](https://prooph-board.com)
+- [DDD Toolbox - Open-source collection of modern web-based tools including Event Storming](https://dddtoolbox.com) ([Source Code](https://github.com/poulainpi/ddd-toolbox))
 - [Event Storming Template for Diagrams.net (formerly known as Draw.io).](https://github.com/josenaldo/event-storming-template)
 
 #### Other resources


### PR DESCRIPTION
This PR adds [DDD Toolbox](https://dddtoolbox.com) to the Remote EventStorming Tools section.

DDD Toolbox is an open-source collection of modern web-based tools for Domain-Driven Design practitioners, including an Event Storming tool for collaborative workshops.

**Live demo:** https://dddtoolbox.com  
**Source code:** https://github.com/poulainpi/ddd-toolbox